### PR TITLE
Update communityNodes.json

### DIFF
--- a/apps/wallet/src/communityNodes.json
+++ b/apps/wallet/src/communityNodes.json
@@ -197,8 +197,8 @@
          "website":"https://ablock.io",
          "payoutSchedule":"Every monday | Lottery",
          "tgContact":"@aorfevrebr",
-         "hide":true,
-         "_comment": "Hidden because node controls ~15% of the total stake"
+         "hide":false,
+         "_comment": "node controls < 10% of the total stake"
       },
       {
          "address":"3JnZLvmVBXsc2XMug4e6yjyvPehr1Fjx9oM",


### PR DESCRIPTION
Updating nodes to reflect hiding of >10% nodes. (ablock has dropped to 8% -> well below 10% so should be shown again)