### PR TITLE
Fix transactions on node v1.3

### DIFF
--- a/apps/wallet/src/app/core/services/ledger.service.ts
+++ b/apps/wallet/src/app/core/services/ledger.service.ts
@@ -263,7 +263,7 @@ export class LedgerServiceImpl implements LedgerService {
 
     const signedTransaction = {
       ...unsignedTransaction,
-      proofs: [signature],
+      signature,
     };
 
     await broadcast(signedTransaction as unknown as TTx<string | number>, this.nodeUrl);

--- a/apps/wallet/src/app/core/services/ledger.service.ts
+++ b/apps/wallet/src/app/core/services/ledger.service.ts
@@ -266,6 +266,10 @@ export class LedgerServiceImpl implements LedgerService {
       signature,
     };
 
+    // workaround for nodes running v1.3 - signature is used instead of proofs
+    // @ts-ignore
+    delete signedTransaction.proofs;
+
     await broadcast(signedTransaction as unknown as TTx<string | number>, this.nodeUrl);
   }
 }


### PR DESCRIPTION
- Adds `signature` in order to fix Ledger transactions on nodes that are running v1.3
- Removes `proofs` array (with a `delete` because type is derived from the library)